### PR TITLE
install kableExtra through github actions

### DIFF
--- a/.github/workflows/deploy_bookdown.yml
+++ b/.github/workflows/deploy_bookdown.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: r-lib/actions/setup-r@v2 # was v1 before
       - uses: r-lib/actions/setup-pandoc@v2 # was v1 before
       - name: Install rmarkdown
-        run: Rscript -e 'install.packages(c("rmarkdown","bookdown"))'
+        run: Rscript -e 'install.packages(c("rmarkdown","bookdown","kableExtra"))'
       - name: Render Book
         run: Rscript -e 'bookdown::render_book("index.Rmd")'
       - uses: actions/upload-artifact@v1

--- a/chapters/12-statistical-privacy.Rmd
+++ b/chapters/12-statistical-privacy.Rmd
@@ -73,7 +73,6 @@ specific individuals in the dataset. It protects against
 # Here is the documentation for kableExtra for html: https://cran.r-project.org/web/packages/kableExtra/vignettes/awesome_table_in_html.html
 # And here it is for LateX/pdf: https://haozhu233.github.io/kableExtra/awesome_table_in_pdf.pdf
 library(knitr)
-install.packages("kableExtra")
 library(kableExtra)
 
 # Sample data frames


### PR DESCRIPTION
<!-- This PR template was adapted from the Turing Way pull request template: 
https://github.com/alan-turing-institute/the-turing-way/edit/master/.github/PULL_REQUEST_TEMPLATE.md 
The text between these little arrows are comments and will not be shown in the pull request text on GitHub! -->

### ℹ️ Summary
There is some ugly looking output relating to installing kableExtra on the [k-anonimity page](https://utrechtuniversity.github.io/dataprivacyhandbook/k-l-t-anonymity.html#k-anonymity): "The downloaded binary packages are in /var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T//Rtmp7mx9jm/downloaded_packages"

This pull requests moves the install to github actions.

### ✅ Related issues (optional)
<!-- Please reference any related issue and use fixes/close to automatically close them, if relevant. 
For example: "Fixes #11", or "Addresses (but does not close) #23" -->
E.g., Fixes issue: #<Issuenumber> (if relevant)

### 📑 Files changed (summary)
.github/workflows/deploy_bookdown.yml: added "kableExtra" to the command installing rmarkdown and bookdown.
chapters/12-statistical-privacy.Rmd: removed install.packages("kableExtra")


### 👀 Review (optional)
<!-- If you have any directions for reviewers, please note them here.
For example, you may guide the reviews to focus on the parts that are ready for comments -->


### 🤲 Acknowledgement
<!-- Please add contributors to this pull request to this repository. You can do so in the following ways:
- Add them in issue #6: https://github.com/UtrechtUniversity/dataprivacyhandbook/issues/6 
- Add them here following the instructions in issue #6 
- Mention here that they should still be added -->
