### PR TITLE
Switch from Google Analytics to Matomo

### DIFF
--- a/book/assets/analytics.html
+++ b/book/assets/analytics.html
@@ -1,20 +1,20 @@
 <!DOCTYPE HTML>
 <!-- Cookie banner code thanks to ChatGPT -->
 <div id="cookie-banner" class="cookie-banner">
-  <p>We use 
+  <p>We use Matomo analytics to track your visit to the Data Privacy Handbook.
+  You can read how in our
   <a href="privacy-policy.html" target="_blank" 
-  style="text-decoration:underline; color:white">cookies</a>
-  to track how you interact with the Data Privacy Handbook. Do you accept?
-  <button id="accept-cookies" class="accept-button">Accept</button>
-  <button id="reject-cookies" class="reject-button">Reject</button>
+  style="text-decoration:underline; color:white">privacy policy</a>.
+  <button id="accept-cookies" class="accept-button">OK</button>
   </p>
 </div>
 
 <script>
   const cookieBanner = document.getElementById('cookie-banner');
   const acceptButton = document.getElementById('accept-cookies');
-  const rejectButton = document.getElementById('reject-cookies');
 
+//Old Analytics Code
+/*
   function insertAnalyticsCode() {
     const analyticsScript = document.createElement('script');
     analyticsScript.async = true;
@@ -28,6 +28,26 @@
       gtag('config', 'G-80JDERE3EZ', {'anonymize_ip': true});
     };
   }
+*/
+
+  function insertAnalyticsCode() {
+    // Matomo. https://matomo.org/faq/general/configure-privacy-settings-in-matomo/
+    var _paq = window._paq = window._paq || [];
+    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+    _paq.push(["disableCampaignParameters"]);
+    //_paq.push(["disableCookies"]); // Should this be disabled? https://matomo.org/faq/general/faq_156/
+    _paq.push(['trackPageView']);
+    _paq.push(['enableLinkTracking']);
+    _paq.push(["setDoNotTrack", true]); // Respect Do Not Track settings
+    
+    (function() {
+      var u="//matomo.hum.uu.nl/";
+      _paq.push(['setTrackerUrl', u+'matomo.php']);
+      _paq.push(['setSiteId', '5']);
+      var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+      g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+    })(); // End Matomo code
+  }
 
   function setCookie(name, value, days) {
     const date = new Date();
@@ -36,6 +56,7 @@
     document.cookie = name + "=" + value + ";" + expires + ";path=/";
   }
 
+/* OLD OLD OLD
   function getCookie(name) {
     const cookieName = name + "=";
     const decodedCookie = decodeURIComponent(document.cookie);
@@ -51,25 +72,42 @@
     }
     return "";
   }
+*/
+
+  function getCookie(name) {
+    const cookieName = name + "=";
+    const decodedCookie = decodeURIComponent(document.cookie);
+    const cookieArray = decodedCookie.split(';');
+    for (let i = 0; i < cookieArray.length; i++) {
+      let cookie = cookieArray[i].trim();
+      if (cookie.indexOf(cookieName) === 0) {
+        return cookie.substring(cookieName.length, cookie.length);
+      }
+    }
+    return "";
+  }
+
 
   // Check if choice is made and hide the banner
   if (getCookie('analyticsChoice') === 'accepted') {
     insertAnalyticsCode();
     cookieBanner.style.display = 'none';
-  } else if (getCookie('analyticsChoice') === 'rejected') {
-    cookieBanner.style.display = 'none';
+  //} else if (getCookie('analyticsChoice') === 'rejected') { // There's no reject button
+  //  cookieBanner.style.display = 'none';
   }
 
   acceptButton.addEventListener('click', () => {
     insertAnalyticsCode();
     setCookie('analyticsChoice', 'accepted', 60);
-    console.log('Consented to analytics cookie');
-    cookieBanner.style.display = 'none';
-  });
-
-  rejectButton.addEventListener('click', () => {
-    setCookie('analyticsChoice', 'rejected', 60);
-    console.log('Rejected analytics cookie');
+    console.log('Clicked OK in cookie banner');
     cookieBanner.style.display = 'none';
   });
 </script>
+<noscript>
+  <p>
+    <img referrerpolicy="no-referrer-when-downgrade" 
+    src="//matomo.hum.uu.nl/matomo.php?idsite=5&amp;rec=1" 
+    style="border:0;" 
+    alt="" />
+  </p>
+</noscript>

--- a/book/assets/style.css
+++ b/book/assets/style.css
@@ -311,16 +311,12 @@ details[open] > summary {
   position: relative; /*this works but at top of page, fixed does not work */
 }
 
-.accept-button, .reject-button {
+.accept-button {
   color: black;
   border: none;
   padding: 5px 10px;
   margin: 0 10px;
   cursor: pointer;
-}
-
-.reject-button {
-  background-color: grey;
 }
 
 .book-header.fixed {

--- a/book/index.Rmd
+++ b/book/index.Rmd
@@ -238,15 +238,15 @@ readers should refer to resources from their own institutions.
 ## Your own privacy {#privacy-policy}
 
 :::keywords
-This page was last updated on 2023-08-28
+This page was last updated on 2025-02-24
 :::
 
-We use Google Analytics to track the usage of the (online version of the) Data 
-Privacy Handbook. We do this, because we want to see how often the Data Privacy 
-Handbook is being visited, how users find it, and which pages are most useful. 
-With your consent, Google Analytics places a tracking cookie in your web 
-browser. The amount of tracked details is limited to:
+As of February 2025, we use Matomo to track the usage of the (online version of the) Data Privacy Handbook. 
+We do this, because we want to see how often the Data Privacy Handbook is being visited, how users find it, and which pages are most useful. 
+When you click "OK" in the cookie banner, Matomo places a tracking cookie in your web browser. 
+The following information is collected about you:
 
+<!-- This list needs to be checked! --> 
 - Which pages you visit and for how long
 - Generic aspects of your behaviour on the page, such as clicks and scrolls
 - How you found the page (e.g., directly or via another website)
@@ -255,21 +255,21 @@ browser. The amount of tracked details is limited to:
 - How you are accessing the page (e.g., via desktop or mobile)
 
 We do not collect your detailed location, and use IP address "anonymisation" to
-prevent other unnecessary details from being collected.
+prevent other unnecessary details from being collected. This ensures that we cannot directly lead your data back to you.
 
-This information is stored at Google for 2 months, and shared with the 
-maintainers of the Data Privacy Handbook and a selection of communication 
-professionals at Utrecht University.
+This information is stored at a local Matomo server in Utrecht (the Netherlands). 
+The analytics are only shared with the maintainers of the Data Privacy Handbook and communication professionals employed at Utrecht University. 
+We do not share any tracking data with external parties. 
+You are not tracked across websites.
+
+<!-- Missing: for how long is the data stored? --> 
 
 :::fyi
-Besides clicking Accept or Reject in the cookie banner, you can also:
-
-- use the 
-[Google Analytics Opt-out Browser Add-on](https://tools.google.com/dlpage/gaoptout){target="_blank"} 
-to prevent websites, including this one, from tracking you
-- disable or block tracking in your browser settings
+If you do not wish to be tracked, you can disable or block tracking in your browser settings. 
+How you can do this depends on your specific browser. 
+Read more about preventing tracking on <http://donottrack.us/>.
 :::
 
 If you have questions or comments about tracking cookies, please consult the 
-[Google Analytics documentation](https://support.google.com/analytics/){target="_blank"} 
+[Matomo documentation](https://matomo.org/){target="_blank"} 
 or [contact us](https://www.uu.nl/en/research/research-data-management/contact-us){target="_blank"}.


### PR DESCRIPTION
### ℹ️ Summary
Switch to Matomo

### 📑 Files changed (summary)
- `index.Rmd`: privacy policy (probably needs an update depending on what Matomo's exact settings are)
- `assets/analytics.html`: replace GA code with Matomo JS, leaving in the cookie banner and dependency on clicking OK for now.
- `assets/style.css`: remove the styling for the Reject button as there is none anymore

### 👀 Review (optional)
Need to check the matomo settings and whether we can do Cookie-less tracking. Perhaps the banner can be updated again then.

### 🤲 Acknowledgement
Thanks to the Centre for Digital Humanities for providing access to their Matomo server.
